### PR TITLE
add: set attack type to make adversarial images

### DIFF
--- a/Environment.py
+++ b/Environment.py
@@ -25,6 +25,7 @@ class Env():
         self.num_epoch = args['num_epoch']
 
         self.model_name: str = args["model_name"]
+        self.train_attack: str = args["train_attack"]
         self.log_path: str = None
 
         self.dataset: np.ndarray = None
@@ -61,8 +62,8 @@ class Env():
         """ 
         _load_dataset 함수는 self.mode에 맞는 original image, perturbed image, label을 불러와 [self.train_dataset, self.val_dataset, self.test_dataset] 중 self.mode에 해당하는 변수에 저장합니다.
         """
-        original_images_paths = glob.glob(f"images/{self.model_name}/origin/{self.mode}/*")
-        perturbed_images_paths = glob.glob(f"images/{self.model_name}/adv/{self.mode}/*")
+        original_images_paths = glob.glob(f"images/{self.model_name}_{self.train_attack}/origin/{self.mode}/*")
+        perturbed_images_paths = glob.glob(f"images/{self.model_name}_{self.train_attack}/adv/{self.mode}/*")
 
         if not original_images_paths :
             raise FileNotFoundError(f"Path not found Error (original_images_paths)")
@@ -116,7 +117,7 @@ class Env():
             return self.transform(img)
         
     def _get_class(self, image_name: str) -> int:
-        return int(image_name.split("_")[1].split(".")[0])
+        return int(image_name.split("_")[2].split(".")[0])
         
     def _load_model(self) -> torch.nn.Module:
         model_path = f"models/{self.model_name}.pt"

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ def parse_opt(known=False):
     parser.add_argument("-a", "--alpha", type=float, default=0.5, help="hyperparameter alpha for cal Reward")
     parser.add_argument("-name", "--model_name", type=str, default="mobilenet", help="attacked DNN model name")
     parser.add_argument("-dataset", "--dataset_name", type=str, default="CIFAR10", help="train dataset name")
+    parser.add_argument("-attack", "--train_attack", type=str, default="PGDLinf", help="attack type to make attacked images")
 
     parser.add_argument("-save", "--image_save", action='store_true', default=False, help="save step images")
     


### PR DESCRIPTION
현재 실험은 PGD attack으로 공격 받은 이미지에 대한 defense  
다양한 attack으로 생성한 이미지에 대한 실험도 필요하다 생각하여 추가

- Adversarial.py
  setAttack 함수 추가
  이미지 저장 경로 변경: images/{model_name}/origin -> images/{model_name}_{attack}

- main.py 
  argparser에 train_attack 추가, 어떤 공격으로 만들어진 이미지를 사용할 것인지 선택

- Environment.py
  images 경로 변경으로 인한 path, split 수정, self.train_attack 변수 추가